### PR TITLE
Python 2.7 Uyumluluğu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+import io
 import setuptools
 
-with open("README.md", "r", encoding='utf-8') as fh:
+with io.open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Merhaba,

`open`'daki encoding parametresi Python 2.7'de desteklenmiyor ve alttaki gibi bir hata ile karşılaşıyorsunuz.

```
"TypeError: 'encoding' is an invalid keyword argument for this function"
```

Dolayısı ile paketi Python 2.7 için de yüklenebilir hale getirdim.